### PR TITLE
Two things:

### DIFF
--- a/man/create_data_list.Rd
+++ b/man/create_data_list.Rd
@@ -4,13 +4,23 @@
 \alias{create_data_list}
 \title{Stan data helper function}
 \usage{
-create_data_list(lavaan_object = NULL, method = "normal", priors = NULL)
+create_data_list(
+  lavaan_object = NULL,
+  method = "normal",
+  simple_struc = TRUE,
+  priors = NULL
+)
 }
 \arguments{
 \item{lavaan_object}{lavaan fit object of corresponding model}
 
 \item{method}{(character) One of "normal", "lasso",
 "logistic", "GDP", "none"}
+
+\item{simple_struc}{(LOGICAL) Only relevant for CFAs.
+If TRUE: assume simple structure;
+If FALSE: estimate all cross-loadings using generalized
+double Pareto priors.}
 
 \item{priors}{An object of \code{\link{mbsempriors-class}}.
 See \code{\link{new_mbsempriors}} for more information.}

--- a/man/minorbsem.Rd
+++ b/man/minorbsem.Rd
@@ -11,6 +11,7 @@ minorbsem(
   sample_nobs = NULL,
   method = "normal",
   orthogonal = FALSE,
+  simple_struc = TRUE,
   seed = 12345,
   warmup = 500,
   sampling = 500,
@@ -52,6 +53,11 @@ Select "none" if intending to ignore the influence of minor factors.}
 
 \item{orthogonal}{(logical) constrain factors orthogonal, must be TRUE to fit
 bifactor models.}
+
+\item{simple_struc}{(LOGICAL) Only relevant for CFAs.
+If TRUE: assume simple structure;
+If FALSE: estimate all cross-loadings using generalized
+double Pareto priors.}
 
 \item{seed}{(positive integer) seed, set to obtain replicable results.}
 

--- a/tests/testthat/test-pretty_print_summary.R
+++ b/tests/testthat/test-pretty_print_summary.R
@@ -17,9 +17,10 @@ test_that("Random method (any case) works for CFA", {
   )
   syntax_idx <- sample(length(model_syntaxes), 1)
   model_syntax <- model_syntaxes[syntax_idx]
+  orthogonal <- sample(c(TRUE, FALSE), 1)
   fit <- minorbsem(
     model_syntax, HS,
-    orthogonal = sample(c(TRUE, FALSE), 1),
+    orthogonal = orthogonal,
     simple_struc = sample(c(TRUE, FALSE), 1),
     method = method, refresh = 0, show_messages = FALSE
   )
@@ -29,11 +30,13 @@ test_that("Random method (any case) works for CFA", {
   )
   mbsem_test_kbls_shared(kbl, method)
   expect_true(regexpr("Residual variances", kbl, ignore.case = TRUE) > 0)
-  expect_true(regexpr(
-    "Inter-factor correlations",
-    kbl,
-    ignore.case = TRUE
-  ) > 0)
+  if (!orthogonal) {
+    expect_true(regexpr(
+      "Inter-factor correlations",
+      kbl,
+      ignore.case = TRUE
+    ) > 0)
+  }
   if (syntax_idx == 3) {
     expect_true(regexpr(
       "Error correlations",


### PR DESCRIPTION
- Fixed a test in pretty print where if `orthogonal = TRUE`, then no reporting of inter-factor correlations
- Updated documentation